### PR TITLE
Implement ClaudeHopper v1.0.0

### DIFF
--- a/ClaudeHopper/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ClaudeHopper/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClaudeHopper/Assets.xcassets/Contents.json
+++ b/ClaudeHopper/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClaudeHopper/Assets.xcassets/StatusBarIcon.imageset/Contents.json
+++ b/ClaudeHopper/Assets.xcassets/StatusBarIcon.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "statusbar-icon.png",
+      "idiom" : "mac",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "statusbar-icon@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/ClaudeHopper/ClaudeHopper.entitlements
+++ b/ClaudeHopper/ClaudeHopper.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/ClaudeHopper/ClaudeHopperApp.swift
+++ b/ClaudeHopper/ClaudeHopperApp.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+@main
+struct ClaudeHopperApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+    var statusItem: NSStatusItem?
+    var popover: NSPopover?
+    
+    // ViewModels
+    let configManager = MCPConfigManager()
+    let discoveryManager = ServerDiscoveryManager()
+    let clipboardManager = ClipboardManager()
+    
+    // Settings
+    @AppStorage("condensedView") var condensedView: Bool = false
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Create the status item
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        
+        if let button = statusItem?.button {
+            // Set the status item image
+            let image = NSImage(named: "StatusBarIcon")
+            button.image = image
+            button.action = #selector(togglePopover)
+            button.target = self
+        }
+        
+        // Create the popover
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: 320, height: 480)
+        popover.behavior = .transient
+        
+        // Set the content view
+        let contentView = MainView()
+            .environmentObject(configManager)
+            .environmentObject(discoveryManager)
+            .environmentObject(clipboardManager)
+            .environmentObject(self)
+        popover.contentViewController = NSHostingController(rootView: contentView)
+        
+        self.popover = popover
+        
+        // Monitor clipboard for MCP configurations
+        clipboardManager.startMonitoring()
+    }
+    
+    @objc func togglePopover() {
+        if let popover = popover {
+            if popover.isShown {
+                popover.close()
+            } else {
+                // Show the popover
+                if let button = statusItem?.button {
+                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                    // Make sure the popover remains focused
+                    popover.contentViewController?.view.window?.makeKey()
+                }
+            }
+        }
+    }
+    
+    // Helper function to open a file dialog for selecting the configuration file
+    func showConfigFileDialog(completion: @escaping (URL?) -> Void) {
+        let openPanel = NSOpenPanel()
+        openPanel.allowsMultipleSelection = false
+        openPanel.canChooseDirectories = false
+        openPanel.canChooseFiles = true
+        openPanel.allowedFileTypes = ["json"]
+        openPanel.prompt = "Select Claude Desktop Config"
+        
+        openPanel.begin { (result) in
+            if result == .OK, let url = openPanel.url {
+                completion(url)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+    
+    // Helper function to open a file dialog for exporting or importing configuration
+    func showSaveFileDialog(title: String, defaultName: String, completion: @escaping (URL?) -> Void) {
+        let savePanel = NSSavePanel()
+        savePanel.title = title
+        savePanel.nameFieldStringValue = defaultName
+        savePanel.allowedFileTypes = ["json"]
+        savePanel.showsTagField = false
+        
+        savePanel.begin { (result) in
+            if result == .OK, let url = savePanel.url {
+                completion(url)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+}

--- a/ClaudeHopper/ClipboardManager.swift
+++ b/ClaudeHopper/ClipboardManager.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Combine
+import AppKit
+
+class ClipboardManager: ObservableObject {
+    @Published var hasDetectedServerConfig: Bool = false
+    @Published var detectedServer: MCPServer?
+    
+    private var timer: Timer?
+    private var lastChangeCount: Int = 0
+    private var configManager: MCPConfigManager?
+    
+    func setConfigManager(_ manager: MCPConfigManager) {
+        self.configManager = manager
+    }
+    
+    func startMonitoring() {
+        // Initialize with current clipboard state
+        lastChangeCount = NSPasteboard.general.changeCount
+        checkClipboard()
+        
+        // Set up timer to check clipboard periodically
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.checkClipboard()
+        }
+    }
+    
+    func stopMonitoring() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    private func checkClipboard() {
+        let pasteboard = NSPasteboard.general
+        
+        // Only check if clipboard has changed
+        guard pasteboard.changeCount != lastChangeCount else {
+            return
+        }
+        
+        lastChangeCount = pasteboard.changeCount
+        
+        // Check for string content
+        guard let clipboardString = pasteboard.string(forType: .string) else {
+            clearDetectedServer()
+            return
+        }
+        
+        // Check if the string contains a server configuration
+        if let server = configManager?.parseConfigBlock(clipboardString) {
+            detectedServer = server
+            hasDetectedServerConfig = true
+        } else {
+            clearDetectedServer()
+        }
+    }
+    
+    func clearDetectedServer() {
+        detectedServer = nil
+        hasDetectedServerConfig = false
+    }
+    
+    func importDetectedServer() -> Bool {
+        guard let server = detectedServer, let configManager = configManager else {
+            return false
+        }
+        
+        // Add the server to the config
+        configManager.addServer(server)
+        
+        // Clear the detected server
+        clearDetectedServer()
+        
+        return true
+    }
+    
+    deinit {
+        stopMonitoring()
+    }
+}

--- a/ClaudeHopper/Info.plist
+++ b/ClaudeHopper/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/ClaudeHopper/MCPServer.swift
+++ b/ClaudeHopper/MCPServer.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// Model representing an MCP server configuration
+struct MCPServer: Identifiable, Equatable, Codable {
+    var id: String { name }
+    var name: String
+    var command: String
+    var args: [String]
+    var enabled: Bool
+    var disabled: Bool = false  // When true, server is preserved but disabled in config
+    var description: String?
+    
+    // Additional properties that aren't persisted but used for UI
+    var isExpanded: Bool = false
+    
+    // Computed property to check if the server is commented out
+    var isCommented: Bool {
+        return name.hasPrefix("// ")
+    }
+    
+    // Computed property to get the uncommented name
+    var uncommentedName: String {
+        if isCommented {
+            return String(name.dropFirst(3))
+        }
+        return name
+    }
+    
+    // Function to comment/uncomment a server name
+    func withCommentStatus(commented: Bool) -> MCPServer {
+        var serverCopy = self
+        if commented && !isCommented {
+            serverCopy.name = "// " + name
+            serverCopy.enabled = false
+        } else if !commented && isCommented {
+            serverCopy.name = uncommentedName
+        }
+        return serverCopy
+    }
+    
+    static func == (lhs: MCPServer, rhs: MCPServer) -> Bool {
+        return lhs.name == rhs.name
+    }
+}
+
+/// Configuration structure that matches Claude Desktop's JSON format
+struct MCPConfiguration: Codable {
+    var mcpServers: [String: ServerConfig]
+    var otherSettings: [String: AnyCodable]? = nil
+    
+    struct ServerConfig: Codable {
+        var command: String
+        var args: [String]
+        var env: [String: String]?
+    }
+    
+    init(servers: [MCPServer]) {
+        // Convert our internal model to the format Claude Desktop expects
+        var mcpServers = [String: ServerConfig]()
+        
+        for server in servers {
+            // Skip disabled or commented servers
+            if server.disabled || server.isCommented {
+                continue
+            }
+            
+            // Only include enabled servers
+            if server.enabled {
+                mcpServers[server.name] = ServerConfig(
+                    command: server.command,
+                    args: server.args,
+                    env: nil
+                )
+            }
+        }
+        
+        self.mcpServers = mcpServers
+    }
+    
+    // This initializer is used when loading from a file
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.mcpServers = try container.decode([String: ServerConfig].self, forKey: .mcpServers)
+        
+        // For other settings, we need to handle them as AnyCodable
+        var otherSettings = [String: AnyCodable]()
+        let allKeys = container.allKeys
+        
+        for key in allKeys {
+            if key != .mcpServers {
+                let value = try container.decode(AnyCodable.self, forKey: key)
+                otherSettings[key.stringValue] = value
+            }
+        }
+        
+        if !otherSettings.isEmpty {
+            self.otherSettings = otherSettings
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mcpServers, forKey: .mcpServers)
+        
+        // Encode other settings if they exist
+        if let otherSettings = otherSettings {
+            for (key, value) in otherSettings {
+                if let codingKey = CodingKeys(stringValue: key) {
+                    try container.encode(value, forKey: codingKey)
+                }
+            }
+        }
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case mcpServers
+        
+        // Support for dynamic keys
+        init?(stringValue: String) {
+            if stringValue == "mcpServers" {
+                self = .mcpServers
+            } else {
+                return nil
+            }
+        }
+        
+        var stringValue: String {
+            switch self {
+            case .mcpServers:
+                return "mcpServers"
+            }
+        }
+        
+        init?(intValue: Int) {
+            return nil
+        }
+        
+        var intValue: Int? {
+            return nil
+        }
+    }
+}
+
+/// AnyCodable type for handling heterogeneous values in the configuration file
+struct AnyCodable: Codable {
+    let value: Any
+    
+    init(_ value: Any) {
+        self.value = value
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if container.decodeNil() {
+            self.value = NSNull()
+        } else if let bool = try? container.decode(Bool.self) {
+            self.value = bool
+        } else if let int = try? container.decode(Int.self) {
+            self.value = int
+        } else if let double = try? container.decode(Double.self) {
+            self.value = double
+        } else if let string = try? container.decode(String.self) {
+            self.value = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            self.value = array.map { $0.value }
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            self.value = dictionary.mapValues { $0.value }
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "AnyCodable cannot decode value"
+            )
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        switch self.value {
+        case is NSNull:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dictionary as [String: Any]:
+            try container.encode(dictionary.mapValues { AnyCodable($0) })
+        default:
+            throw EncodingError.invalidValue(
+                self.value,
+                EncodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "AnyCodable cannot encode value"
+                )
+            )
+        }
+    }
+}

--- a/ClaudeHopper/MainView.swift
+++ b/ClaudeHopper/MainView.swift
@@ -1,0 +1,496 @@
+import SwiftUI
+
+struct MainView: View {
+    @EnvironmentObject var configManager: MCPConfigManager
+    @EnvironmentObject var discoveryManager: ServerDiscoveryManager
+    @EnvironmentObject var clipboardManager: ClipboardManager
+    @EnvironmentObject var appDelegate: AppDelegate
+    
+    @AppStorage("condensedView") private var condensedView: Bool = false
+    @State private var showSettings = false
+    @State private var showAddServerSheet = false
+    @State private var selectedServer: MCPServer? = nil
+    @State private var showPasteNotification = false
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Image("AppIcon")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                
+                Text("ClaudeHopper")
+                    .font(.headline)
+                
+                Spacer()
+                
+                Button(action: {
+                    showSettings.toggle()
+                }) {
+                    Image(systemName: "gear")
+                        .font(.system(size: 14))
+                }
+                .buttonStyle(PlainButtonStyle())
+                .popover(isPresented: $showSettings) {
+                    SettingsView()
+                        .frame(width: 300, height: 400)
+                }
+            }
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            
+            Divider()
+            
+            // Configuration Path Warning
+            if configManager.configPath == nil {
+                VStack {
+                    Text("Configuration file not found")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                        .padding(.top, 8)
+                    
+                    Text("Please select your Claude Desktop configuration file")
+                        .font(.caption)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                    
+                    Button("Select Config File") {
+                        appDelegate.showConfigFileDialog { url in
+                            if let url = url {
+                                configManager.setConfigPath(url)
+                            }
+                        }
+                    }
+                    .padding(.top, 4)
+                    .padding(.bottom, 8)
+                }
+                .padding()
+                .background(Color(NSColor.controlBackgroundColor).opacity(0.8))
+            }
+            
+            // Clipboard Detection Banner
+            if clipboardManager.hasDetectedServerConfig {
+                ClipboardServerBanner(clipboardManager: clipboardManager, showNotification: $showPasteNotification)
+                    .transition(.move(edge: .top))
+            }
+            
+            // Error Message
+            if let errorMessage = configManager.errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+            }
+            
+            if let errorMessage = discoveryManager.errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+            }
+            
+            // Content Area
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    // Active Servers Section
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Active Servers")
+                                .font(.headline)
+                            
+                            Spacer()
+                            
+                            Button(action: {
+                                condensedView.toggle()
+                            }) {
+                                Image(systemName: condensedView ? "list.bullet" : "list.dash")
+                                    .font(.system(size: 12))
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .help(condensedView ? "Show details" : "Condensed view")
+                        }
+                        .padding(.horizontal)
+                        
+                        if configManager.servers.isEmpty {
+                            Text("No servers configured")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .padding()
+                        } else {
+                            ForEach(configManager.servers) { server in
+                                ActiveServerRow(server: server, condensedView: condensedView, onEdit: {
+                                    selectedServer = server
+                                })
+                                    .environmentObject(configManager)
+                            }
+                        }
+                    }
+                    
+                    Divider()
+                        .padding(.vertical, 4)
+                    
+                    // Available Servers Section
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Available Servers")
+                                .font(.headline)
+                            
+                            Spacer()
+                            
+                            // Refresh button
+                            Button(action: {
+                                discoveryManager.discoverServers()
+                            }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.system(size: 12))
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .disabled(discoveryManager.isDiscovering)
+                            .help("Refresh available servers")
+                        }
+                        .padding(.horizontal)
+                        
+                        // Discovery progress indicator
+                        if discoveryManager.isDiscovering {
+                            HStack {
+                                ProgressView()
+                                    .scaleEffect(0.5)
+                                
+                                Text("Discovering servers...")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            }
+                            .padding(.horizontal)
+                        } else if let lastDiscovery = discoveryManager.lastDiscoveryTime {
+                            Text("Last updated: \(formattedDate(lastDiscovery))")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .padding(.horizontal)
+                        }
+                        
+                        // Available servers list
+                        let availableServers = discoveryManager.filterAvailableServers(configuredServers: configManager.servers)
+                        
+                        if availableServers.isEmpty {
+                            Text(discoveryManager.isDiscovering ? "Discovering..." : "No additional servers available")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .padding()
+                        } else {
+                            ForEach(availableServers) { server in
+                                AvailableServerRow(server: server, condensedView: condensedView)
+                                    .environmentObject(configManager)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical)
+            }
+            
+            Divider()
+            
+            // Footer
+            HStack {
+                Button(action: {
+                    showAddServerSheet = true
+                }) {
+                    HStack {
+                        Image(systemName: "plus")
+                        Text("Add Custom Server")
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("Add a custom MCP server")
+                
+                Spacer()
+                
+                if let configPath = configManager.configPath {
+                    Text(configPath.lastPathComponent)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(Color(NSColor.controlBackgroundColor))
+        }
+        .frame(width: 320, height: 480)
+        .sheet(isPresented: $showAddServerSheet) {
+            ServerVerificationView(showSheet: $showAddServerSheet, server: MCPServer(name: "", command: "", args: [], enabled: true))
+                .environmentObject(configManager)
+        }
+        .sheet(item: $selectedServer) { server in
+            ServerVerificationView(showSheet: .constant(true), server: server, isEditing: true, onDismiss: {
+                selectedServer = nil
+            })
+                .environmentObject(configManager)
+        }
+        .onAppear {
+            // Set up clipboard manager with config manager
+            clipboardManager.setConfigManager(configManager)
+        }
+        .overlay(alignment: .top) {
+            if showPasteNotification {
+                VStack {
+                    Text("Server added!")
+                        .font(.callout)
+                        .padding(8)
+                        .background(Color.green.opacity(0.8))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+                .padding(.top, 60)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        withAnimation {
+                            showPasteNotification = false
+                        }
+                    }
+                }
+            }
+        }
+        .animation(.default, value: clipboardManager.hasDetectedServerConfig)
+    }
+    
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Clipboard Server Banner
+struct ClipboardServerBanner: View {
+    @ObservedObject var clipboardManager: ClipboardManager
+    @Binding var showNotification: Bool
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: "clipboard")
+                    .foregroundColor(.blue)
+                
+                Text("MCP Server Detected in Clipboard")
+                    .font(.callout.bold())
+                
+                Spacer()
+                
+                Button(action: {
+                    clipboardManager.clearDetectedServer()
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.caption)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            
+            if let server = clipboardManager.detectedServer {
+                Text("Name: \(server.name)")
+                    .font(.caption)
+                
+                HStack {
+                    Button(action: {
+                        let success = clipboardManager.importDetectedServer()
+                        if success {
+                            showNotification = true
+                        }
+                    }) {
+                        Text("Add to Configuration")
+                            .font(.caption)
+                    }
+                    .buttonStyle(BorderlessButtonStyle())
+                    
+                    Spacer()
+                }
+            }
+        }
+        .padding()
+        .background(Color.blue.opacity(0.1))
+        .cornerRadius(8)
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Active Server Row
+struct ActiveServerRow: View {
+    @EnvironmentObject var configManager: MCPConfigManager
+    
+    let server: MCPServer
+    let condensedView: Bool
+    var onEdit: () -> Void
+    
+    @State private var showContextMenu = false
+    
+    var body: some View {
+        HStack {
+            // Toggle switch for enabling/disabling
+            Toggle("", isOn: Binding(
+                get: { server.enabled },
+                set: { newValue in
+                    // Create a copy with the updated enabled state
+                    var updatedServer = server
+                    updatedServer.enabled = newValue
+                    
+                    // If enabling a disabled server, also undisable it
+                    if newValue && server.disabled {
+                        updatedServer.disabled = false
+                        updatedServer.name = server.isCommented ? server.uncommentedName : server.name
+                    }
+                    
+                    // Find and update the server in the list
+                    if let index = configManager.servers.firstIndex(where: { $0.name == server.name }) {
+                        configManager.servers[index] = updatedServer
+                        configManager.objectWillChange.send()
+                        configManager.saveConfiguration()
+                    }
+                }
+            ))
+            .toggleStyle(SwitchToggleStyle())
+            .disabled(server.disabled || server.isCommented)
+            
+            // Server name and details
+            VStack(alignment: .leading) {
+                Text(server.isCommented ? server.uncommentedName : server.name)
+                    .strikethrough(server.disabled || server.isCommented)
+                    .foregroundColor(server.disabled || server.isCommented ? .gray : .primary)
+                
+                if !condensedView, let description = server.description {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+                
+                if !condensedView {
+                    Text("\(server.command) \(server.args.joined(separator: " "))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            // Context menu button
+            Button(action: {
+                showContextMenu = true
+            }) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(PlainButtonStyle())
+            .popover(isPresented: $showContextMenu) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Button(action: {
+                        showContextMenu = false
+                        onEdit()
+                    }) {
+                        Label("Edit Server", systemImage: "pencil")
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    
+                    Button(action: {
+                        configManager.toggleServerDisabled(server)
+                        showContextMenu = false
+                    }) {
+                        if server.disabled || server.isCommented {
+                            Label("Enable Server", systemImage: "checkmark.circle")
+                        } else {
+                            Label("Disable Server", systemImage: "slash.circle")
+                        }
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    
+                    Divider()
+                    
+                    Button(action: {
+                        configManager.removeServer(server)
+                        showContextMenu = false
+                    }) {
+                        Label("Remove Server", systemImage: "trash")
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .padding()
+                .frame(width: 180)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 4)
+        .contextMenu {
+            Button(action: {
+                onEdit()
+            }) {
+                Label("Edit Server", systemImage: "pencil")
+            }
+            
+            Button(action: {
+                configManager.toggleServerDisabled(server)
+            }) {
+                if server.disabled || server.isCommented {
+                    Label("Enable Server", systemImage: "checkmark.circle")
+                } else {
+                    Label("Disable Server", systemImage: "slash.circle")
+                }
+            }
+            
+            Divider()
+            
+            Button(action: {
+                configManager.removeServer(server)
+            }) {
+                Label("Remove Server", systemImage: "trash")
+                    .foregroundColor(.red)
+            }
+        }
+    }
+}
+
+// MARK: - Available Server Row
+struct AvailableServerRow: View {
+    @EnvironmentObject var configManager: MCPConfigManager
+    
+    let server: MCPServer
+    let condensedView: Bool
+    
+    @State private var showVerification = false
+    
+    var body: some View {
+        HStack {
+            // Server name and details
+            VStack(alignment: .leading) {
+                Text(server.name)
+                
+                if !condensedView, let description = server.description {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+            
+            Spacer()
+            
+            // Add button
+            Button(action: {
+                showVerification = true
+            }) {
+                Text("Add")
+                    .font(.caption)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 4)
+        .sheet(isPresented: $showVerification) {
+            ServerVerificationView(showSheet: $showVerification, server: server)
+                .environmentObject(configManager)
+        }
+    }
+}

--- a/ClaudeHopper/ServerDiscoveryManager.swift
+++ b/ClaudeHopper/ServerDiscoveryManager.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Combine
+
+class ServerDiscoveryManager: ObservableObject {
+    @Published var availableServers: [MCPServer] = []
+    @Published var isDiscovering: Bool = false
+    @Published var errorMessage: String?
+    @Published var lastDiscoveryTime: Date?
+    
+    private var cancellables = Set<AnyCancellable>()
+    private let cacheKey = "discoveredServersCache"
+    private let cacheExpirationHours = 24.0 // Cache for 24 hours
+    
+    init() {
+        loadCachedServers()
+    }
+    
+    /// Load the cached servers from UserDefaults
+    private func loadCachedServers() {
+        guard let cachedData = UserDefaults.standard.data(forKey: cacheKey),
+              let cacheTime = UserDefaults.standard.object(forKey: "\(cacheKey)_time") as? Date else {
+            // No cache or cache time, perform discovery
+            discoverServers()
+            return
+        }
+        
+        // Check if cache is expired
+        let hoursElapsed = Date().timeIntervalSince(cacheTime) / 3600
+        if hoursElapsed > cacheExpirationHours {
+            // Cache expired, perform discovery
+            discoverServers()
+            return
+        }
+        
+        // Load from cache
+        do {
+            let decoder = JSONDecoder()
+            let cachedServers = try decoder.decode([MCPServer].self, from: cachedData)
+            self.availableServers = cachedServers
+            self.lastDiscoveryTime = cacheTime
+        } catch {
+            print("Failed to decode cached servers: \(error)")
+            discoverServers()
+        }
+    }
+    
+    /// Save the discovered servers to the cache
+    private func saveServersToCache() {
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(availableServers)
+            UserDefaults.standard.set(data, forKey: cacheKey)
+            UserDefaults.standard.set(Date(), forKey: "\(cacheKey)_time")
+        } catch {
+            print("Failed to cache servers: \(error)")
+        }
+    }
+    
+    /// Discover available MCP servers
+    func discoverServers() {
+        isDiscovering = true
+        errorMessage = nil
+        
+        // Define sources for server discovery
+        let sources = [
+            "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/package.json",
+            "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/src/package.json"
+        ]
+        
+        var discoveredServers: [MCPServer] = []
+        let group = DispatchGroup()
+        
+        for source in sources {
+            group.enter()
+            
+            // Create URL request for the source
+            guard let url = URL(string: source) else {
+                group.leave()
+                continue
+            }
+            
+            URLSession.shared.dataTaskPublisher(for: url)
+                .map { $0.data }
+                .decode(type: PackageJSON.self, decoder: JSONDecoder())
+                .receive(on: DispatchQueue.main)
+                .sink(receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case .failure(let error):
+                        print("Failed to fetch from \(source): \(error)")
+                    }
+                    group.leave()
+                }, receiveValue: { packageJSON in
+                    // Extract server info from the package.json
+                    if let dependencies = packageJSON.dependencies {
+                        for (name, version) in dependencies {
+                            if name.contains("server") {
+                                let serverName = name.replacingOccurrences(of: "@modelcontextprotocol/server-", with: "")
+                                
+                                // Create a server object
+                                let server = MCPServer(
+                                    name: serverName,
+                                    command: "npx",
+                                    args: ["-y", name],
+                                    enabled: false,
+                                    description: "Official MCP server: \(serverName)"
+                                )
+                                
+                                // Add to discovered servers if not already present
+                                if !discoveredServers.contains(where: { $0.name == server.name }) {
+                                    discoveredServers.append(server)
+                                }
+                            }
+                        }
+                    }
+                })
+                .store(in: &cancellables)
+        }
+        
+        // After all sources have been processed
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self else { return }
+            
+            // Add some manually known community servers
+            let communityServers = [
+                MCPServer(
+                    name: "filesystem",
+                    command: "npx",
+                    args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/files"],
+                    enabled: false,
+                    description: "Access files on your computer"
+                ),
+                MCPServer(
+                    name: "github",
+                    command: "npx",
+                    args: ["-y", "@modelcontextprotocol/server-github"],
+                    enabled: false,
+                    description: "Interact with GitHub repositories"
+                ),
+                MCPServer(
+                    name: "brave-search",
+                    command: "npx",
+                    args: ["-y", "@modelcontextprotocol/server-brave-search"],
+                    enabled: false,
+                    description: "Search the web using Brave Search"
+                ),
+                MCPServer(
+                    name: "postgres",
+                    command: "npx",
+                    args: ["-y", "@modelcontextprotocol/server-postgres", "postgresql://username:password@localhost/dbname"],
+                    enabled: false,
+                    description: "Access PostgreSQL databases"
+                )
+            ]
+            
+            // Add community servers that aren't already discovered
+            for server in communityServers {
+                if !discoveredServers.contains(where: { $0.name == server.name }) {
+                    discoveredServers.append(server)
+                }
+            }
+            
+            self.availableServers = discoveredServers.sorted(by: { $0.name < $1.name })
+            self.isDiscovering = false
+            self.lastDiscoveryTime = Date()
+            
+            // Cache the discovered servers
+            self.saveServersToCache()
+        }
+    }
+    
+    /// Filter out servers that are already in the configuration
+    func filterAvailableServers(configuredServers: [MCPServer]) -> [MCPServer] {
+        let configuredNames = Set(configuredServers.map { $0.uncommentedName })
+        return availableServers.filter { !configuredNames.contains($0.name) }
+    }
+}
+
+// MARK: - Models for parsing package.json
+struct PackageJSON: Codable {
+    var dependencies: [String: String]?
+}

--- a/ClaudeHopper/ServerVerificationView.swift
+++ b/ClaudeHopper/ServerVerificationView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+struct ServerVerificationView: View {
+    @EnvironmentObject var configManager: MCPConfigManager
+    @Binding var showSheet: Bool
+    @State var server: MCPServer
+    var isEditing: Bool = false
+    var onDismiss: (() -> Void)? = nil
+    
+    @State private var showFolderPicker = false
+    @State private var errorMessage: String?
+    @State private var selectedFolder: URL?
+    @State private var apiToken: String = ""
+    @State private var serverType: ServerType = .generic
+    
+    enum ServerType: String, CaseIterable, Identifiable {
+        case generic = "Generic"
+        case filesystem = "Filesystem"
+        case github = "GitHub"
+        
+        var id: String { self.rawValue }
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            Text(isEditing ? "Edit Server" : "Add Server")
+                .font(.headline)
+            
+            Divider()
+            
+            // Server type picker (only for new servers)
+            if !isEditing {
+                Picker("Server Type", selection: $serverType) {
+                    ForEach(ServerType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .onChange(of: serverType) { newValue in
+                    updateServerForType(newValue)
+                }
+            }
+            
+            // Server name
+            VStack(alignment: .leading) {
+                Text("Server Name")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                TextField("Server name", text: $server.name)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+            
+            // Command
+            VStack(alignment: .leading) {
+                Text("Command")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                TextField("Command (e.g., npx)", text: $server.command)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+            
+            // Arguments
+            VStack(alignment: .leading) {
+                Text("Arguments")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                if serverType == .filesystem {
+                    HStack {
+                        TextField("Arguments", text: Binding(
+                            get: { server.args.joined(separator: " ") },
+                            set: { newValue in 
+                                server.args = newValue.split(separator: " ").map(String.init)
+                            }
+                        ))
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        
+                        Button("Browse") {
+                            showFolderPicker = true
+                        }
+                        .fileImporter(
+                            isPresented: $showFolderPicker,
+                            allowedContentTypes: [.folder],
+                            allowsMultipleSelection: false
+                        ) { result in
+                            switch result {
+                            case .success(let urls):
+                                if let url = urls.first {
+                                    selectedFolder = url
+                                    
+                                    // Update the arguments to include the folder path
+                                    let baseArgs = ["-y", "@modelcontextprotocol/server-filesystem"]
+                                    server.args = baseArgs + [url.path]
+                                }
+                            case .failure(let error):
+                                errorMessage = "Error selecting folder: \(error.localizedDescription)"
+                            }
+                        }
+                    }
+                    
+                    if let selectedFolder = selectedFolder {
+                        Text("Selected: \(selectedFolder.lastPathComponent)")
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                    }
+                } else if serverType == .github {
+                    VStack(alignment: .leading, spacing: 8) {
+                        TextField("Arguments", text: Binding(
+                            get: { server.args.joined(separator: " ") },
+                            set: { newValue in 
+                                server.args = newValue.split(separator: " ").map(String.init)
+                            }
+                        ))
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        
+                        Divider()
+                        
+                        Text("GitHub API Token")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        SecureField("Personal Access Token", text: $apiToken)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                        
+                        Text("The token will be stored in the Claude Desktop configuration.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    TextField("Arguments", text: Binding(
+                        get: { server.args.joined(separator: " ") },
+                        set: { newValue in 
+                            server.args = newValue.split(separator: " ").map(String.init)
+                        }
+                    ))
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                }
+            }
+            
+            // Description
+            VStack(alignment: .leading) {
+                Text("Description (optional)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                TextField("Server description", text: Binding(
+                    get: { server.description ?? "" },
+                    set: { server.description = $0.isEmpty ? nil : $0 }
+                ))
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            }
+            
+            // Error message
+            if let errorMessage = errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+            
+            Spacer()
+            
+            // Action buttons
+            HStack {
+                Button("Cancel") {
+                    showSheet = false
+                    onDismiss?() // Call the dismiss callback if provided
+                }
+                
+                Spacer()
+                
+                Button(isEditing ? "Update" : "Add") {
+                    if validateServer() {
+                        if isEditing {
+                            // Update existing server
+                            if let index = configManager.servers.firstIndex(where: { $0.name == server.name }) {
+                                configManager.servers[index] = server
+                                configManager.objectWillChange.send()
+                                configManager.saveConfiguration()
+                            }
+                        } else {
+                            // Add new server
+                            configManager.addServer(server)
+                        }
+                        showSheet = false
+                        onDismiss?() // Call the dismiss callback if provided
+                    }
+                }
+                .disabled(!isValidServer())
+            }
+        }
+        .padding()
+        .frame(width: 400, height: 500)
+        .onAppear {
+            // Initialize the server type based on the server name or command
+            if server.name.contains("filesystem") || server.command.contains("filesystem") {
+                serverType = .filesystem
+            } else if server.name.contains("github") || server.command.contains("github") {
+                serverType = .github
+                
+                // Parse API token from environment if present
+                if let envIndex = server.args.firstIndex(where: { $0.contains("GITHUB_PERSONAL_ACCESS_TOKEN") }) {
+                    let envStr = server.args[envIndex]
+                    if let tokenStartIndex = envStr.firstIndex(of: "=") {
+                        let tokenSubstring = envStr[envStr.index(after: tokenStartIndex)...]
+                        apiToken = String(tokenSubstring)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func updateServerForType(_ type: ServerType) {
+        switch type {
+        case .filesystem:
+            server.name = "filesystem"
+            server.command = "npx"
+            server.args = ["-y", "@modelcontextprotocol/server-filesystem"]
+            server.description = "Access files on your computer"
+        case .github:
+            server.name = "github"
+            server.command = "npx"
+            server.args = ["-y", "@modelcontextprotocol/server-github"]
+            server.description = "GitHub integration"
+        case .generic:
+            server.name = ""
+            server.command = "npx"
+            server.args = ["-y"]
+            server.description = ""
+        }
+    }
+    
+    private func isValidServer() -> Bool {
+        return !server.name.isEmpty && !server.command.isEmpty
+    }
+    
+    private func validateServer() -> Bool {
+        // Basic validation
+        if server.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errorMessage = "Server name is required"
+            return false
+        }
+        
+        if server.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errorMessage = "Command is required"
+            return false
+        }
+        
+        // Specific validation for server types
+        if serverType == .filesystem {
+            if server.args.count < 3 || !server.args[2].hasPrefix("/") {
+                errorMessage = "Please select a folder for the filesystem server"
+                return false
+            }
+        } else if serverType == .github && !apiToken.isEmpty {
+            // Add environment variables for GitHub token
+            server.args.append("--env.GITHUB_PERSONAL_ACCESS_TOKEN=\(apiToken)")
+        }
+        
+        return true
+    }
+}

--- a/ClaudeHopper/SettingsView.swift
+++ b/ClaudeHopper/SettingsView.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var configManager: MCPConfigManager
+    @EnvironmentObject var discoveryManager: ServerDiscoveryManager
+    @EnvironmentObject var appDelegate: AppDelegate
+    
+    @AppStorage("condensedView") private var condensedView: Bool = false
+    @AppStorage("checkForServersOnStartup") private var checkForServersOnStartup: Bool = true
+    
+    @State private var showImportDialog = false
+    @State private var showExportDialog = false
+    @State private var showBackupDialog = false
+    @State private var showRestoreDialog = false
+    @State private var showConfigPathDialog = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings")
+                .font(.headline)
+            
+            Divider()
+            
+            // Display options
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Display Options")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                
+                Toggle("Condensed View", isOn: $condensedView)
+                    .toggleStyle(SwitchToggleStyle())
+                
+                Toggle("Check for New Servers on Startup", isOn: $checkForServersOnStartup)
+                    .toggleStyle(SwitchToggleStyle())
+            }
+            
+            Divider()
+            
+            // Configuration
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Configuration")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                
+                if let configPath = configManager.configPath {
+                    HStack {
+                        Text("Config File:")
+                            .font(.caption)
+                        
+                        Text(configPath.path)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                } else {
+                    Text("No configuration file selected")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+                
+                Button("Change Configuration Path") {
+                    showConfigPathDialog = true
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            
+            Divider()
+            
+            // Import/Export
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Import/Export")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                
+                HStack {
+                    Button("Import Servers") {
+                        showImportDialog = true
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    
+                    Spacer()
+                    
+                    Button("Export Servers") {
+                        showExportDialog = true
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(configManager.servers.isEmpty)
+                }
+                
+                HStack {
+                    Button("Backup Configuration") {
+                        showBackupDialog = true
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(configManager.configPath == nil)
+                    
+                    Spacer()
+                    
+                    Button("Restore Configuration") {
+                        showRestoreDialog = true
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .disabled(configManager.configPath == nil)
+                }
+            }
+            
+            Spacer()
+            
+            // About
+            VStack(alignment: .center, spacing: 4) {
+                Text("ClaudeHopper")
+                    .font(.headline)
+                
+                Text("Version 1.0.0")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                Link("GitHub Repository", destination: URL(string: "https://github.com/Arborist-ai/ClaudeHopper")!)
+                    .font(.caption)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding()
+        .onChange(of: showConfigPathDialog) { isShowing in
+            if isShowing {
+                appDelegate.showConfigFileDialog { url in
+                    if let url = url {
+                        configManager.setConfigPath(url)
+                    }
+                    showConfigPathDialog = false
+                }
+            }
+        }
+        .onChange(of: showImportDialog) { isShowing in
+            if isShowing {
+                let openPanel = NSOpenPanel()
+                openPanel.allowsMultipleSelection = false
+                openPanel.canChooseDirectories = false
+                openPanel.canChooseFiles = true
+                openPanel.allowedFileTypes = ["json"]
+                openPanel.prompt = "Import Servers"
+                
+                openPanel.begin { result in
+                    if result == .OK, let url = openPanel.url {
+                        configManager.importConfiguration(from: url)
+                    }
+                    showImportDialog = false
+                }
+            }
+        }
+        .onChange(of: showExportDialog) { isShowing in
+            if isShowing {
+                appDelegate.showSaveFileDialog(
+                    title: "Export Servers",
+                    defaultName: "claudehopper_servers.json"
+                ) { url in
+                    if let url = url {
+                        configManager.exportConfiguration(to: url)
+                    }
+                    showExportDialog = false
+                }
+            }
+        }
+        .onChange(of: showBackupDialog) { isShowing in
+            if isShowing {
+                appDelegate.showSaveFileDialog(
+                    title: "Backup Configuration",
+                    defaultName: "claude_desktop_config_backup.json"
+                ) { url in
+                    if let url = url {
+                        configManager.backupConfiguration(to: url)
+                    }
+                    showBackupDialog = false
+                }
+            }
+        }
+        .onChange(of: showRestoreDialog) { isShowing in
+            if isShowing {
+                let openPanel = NSOpenPanel()
+                openPanel.allowsMultipleSelection = false
+                openPanel.canChooseDirectories = false
+                openPanel.canChooseFiles = true
+                openPanel.allowedFileTypes = ["json"]
+                openPanel.prompt = "Restore Configuration"
+                
+                openPanel.begin { result in
+                    if result == .OK, let url = openPanel.url {
+                        configManager.restoreConfiguration(from: url)
+                    }
+                    showRestoreDialog = false
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ ClaudeHopper provides a simple, intuitive interface for managing MCP servers tha
 - Fetch up-to-date configurations for servers
 - Manually add custom servers
 - Check for new servers periodically
+- Import server configurations directly from clipboard
 
 ## Features
 
 - **Server Management**: Enable, disable, add, and remove MCP servers from your Claude Desktop configuration
 - **Real Server Discovery**: Fetch available servers from the official MCP servers repository
+- **Clipboard Monitoring**: Automatically detect and import server configurations copied from websites
 - **Configuration Backups**: Easily backup and restore your server configurations
 - **User-Friendly Interface**: Simple menu bar app with intuitive controls
 


### PR DESCRIPTION
This PR implements the ClaudeHopper application, a macOS menu bar utility for managing MCP servers in Claude Desktop.

## Key Features

- Menu bar application for easy access
- Server management with toggle switches
- Server discovery from official repositories
- Server configuration via clipboard import
- Backup and restore functionality
- User-friendly interface with detailed server information

## Implementation Details

- Built with SwiftUI for macOS
- Finds and manages Claude Desktop's configuration file
- Preserves commented-out server entries
- Automatic clipboard detection for server configurations
- Custom views for different server types (Filesystem, GitHub, etc.)

This implementation allows users to easily manage their MCP server configurations without having to manually edit JSON files, and provides a streamlined way to discover and add new servers as they become available.